### PR TITLE
🐛 [2025-07-20] 修复 BUG: 安全地获取所有核心设备属性（name, agt, me, devtype）

### DIFF
--- a/custom_components/lifesmart/__init__.py
+++ b/custom_components/lifesmart/__init__.py
@@ -529,9 +529,9 @@ class LifeSmartDevice(Entity):
             dev.get(DEVICE_NAME_KEY) or f"Unnamed {dev.get(DEVICE_TYPE_KEY, 'Device')}"
         )
         self._device_name = self._name
-        self._agt = dev[HUB_ID_KEY]
-        self._me = dev[DEVICE_ID_KEY]
-        self._devtype = dev[DEVICE_TYPE_KEY]
+        self._agt = dev.get(HUB_ID_KEY)
+        self._me = dev.get(DEVICE_ID_KEY)
+        self._devtype = dev.get(DEVICE_TYPE_KEY)
         self._client = lifesmart_client
         self._attributes = {
             HUB_ID_KEY: self._agt,

--- a/custom_components/lifesmart/__init__.py
+++ b/custom_components/lifesmart/__init__.py
@@ -525,8 +525,10 @@ class LifeSmartDevice(Entity):
             dev: 从 API 获取的设备信息字典。
             lifesmart_client: LifeSmart 客户端实例。
         """
-        self._name = dev[DEVICE_NAME_KEY]
-        self._device_name = dev[DEVICE_NAME_KEY]
+        self._name = (
+            dev.get(DEVICE_NAME_KEY) or f"Unnamed {dev.get(DEVICE_TYPE_KEY, 'Device')}"
+        )
+        self._device_name = self._name
         self._agt = dev[HUB_ID_KEY]
         self._me = dev[DEVICE_ID_KEY]
         self._devtype = dev[DEVICE_TYPE_KEY]

--- a/custom_components/lifesmart/binary_sensor.py
+++ b/custom_components/lifesmart/binary_sensor.py
@@ -205,7 +205,28 @@ class LifeSmartBinarySensor(BinarySensorEntity):
 
     @callback
     def _generate_sensor_name(self) -> str:
-        """Generate user-friendly sensor name."""
+        """
+        Generate a user-friendly name for the binary sensor.
+
+        The naming strategy combines the base device name with the sub-device name or key:
+        - If the sub-device has a specific name (and it differs from the sub-device key), 
+          the name is formatted as "{base_name} {sub_name}".
+        - Otherwise, the name is formatted as "{base_name} {sub_key.upper()}".
+
+        Parameters:
+        - self._raw_device: A dictionary containing the raw device data, including the base name.
+        - self._sub_data: A dictionary containing the sub-device data, including the sub-device name.
+        - self._sub_key: A string representing the sub-device key (e.g., an I/O port index).
+
+        Returns:
+        - A string representing the user-friendly name of the sensor.
+
+        Examples:
+        - Base name: "Living Room Sensor", Sub-device name: "Motion Detector"
+          -> "Living Room Sensor Motion Detector"
+        - Base name: "Living Room Sensor", Sub-device key: "io1"
+          -> "Living Room Sensor IO1"
+        """
         base_name = self._raw_device.get(DEVICE_NAME_KEY, "Unknown Device")
         # 如果子设备有自己的名字，则使用它
         sub_name = self._sub_data.get(DEVICE_NAME_KEY)

--- a/custom_components/lifesmart/climate.py
+++ b/custom_components/lifesmart/climate.py
@@ -357,26 +357,31 @@ class LifeSmartClimate(ClimateEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """返回设备信息以链接实体到单个设备。"""
+        # 从 self._raw_device 中安全地获取 hub_id 和 device_id
+        hub_id = self._raw_device.get(HUB_ID_KEY)
+        device_id = self._raw_device.get(DEVICE_ID_KEY)
+
+        # 确保 identifiers 即使在 hub_id 或 device_id 为 None 的情况下也不会出错
+        identifiers = set()
+        if hub_id and device_id:
+            identifiers.add((DOMAIN, hub_id, device_id))
+
         return DeviceInfo(
-            identifiers={
-                (DOMAIN, self._raw_device[HUB_ID_KEY], self._raw_device[DEVICE_ID_KEY])
-            },
-            name=self._raw_device[DEVICE_NAME_KEY],
+            identifiers=identifiers,
+            name=self._raw_device.get(
+                DEVICE_NAME_KEY, "Unnamed Device"
+            ),  # 安全获取名称
             manufacturer=MANUFACTURER,
-            model=self._raw_device[DEVICE_TYPE_KEY],
+            model=self._raw_device.get(DEVICE_TYPE_KEY),  # 安全获取型号
             sw_version=self._raw_device.get(DEVICE_VERSION_KEY, "unknown"),
-            via_device=(
-                (DOMAIN, self._raw_device[HUB_ID_KEY])
-                if self._raw_device[HUB_ID_KEY]
-                else None
-            ),
+            via_device=((DOMAIN, hub_id) if hub_id else None),
         )
 
     async def async_added_to_hass(self) -> None:
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,
-                f"{LIFESMART_SIGNAL_UPDATE_ENTITY}_{self.unique_id}",
+                f"{LIFESMART_SIGNAL_UPDATE_ENTITY}_{self._attr_unique_id}",
                 self._handle_update,
             )
         )
@@ -402,5 +407,5 @@ class LifeSmartClimate(ClimateEntity):
                 self._update_state(current_device.get(DEVICE_DATA_KEY, {}))
         except (KeyError, StopIteration):
             _LOGGER.warning(
-                "Could not find device %s during global refresh.", self.unique_id
+                "Could not find device %s during global refresh.", self._attr_unique_id
             )

--- a/custom_components/lifesmart/cover.py
+++ b/custom_components/lifesmart/cover.py
@@ -159,27 +159,32 @@ class LifeSmartCover(CoverEntity):
 
     @property
     def device_info(self) -> DeviceInfo:
-        """Return device info to link entities to a single device."""
+        """返回设备信息以链接实体到单个设备。"""
+        # 从 self._raw_device 中安全地获取 hub_id 和 device_id
+        hub_id = self._raw_device.get(HUB_ID_KEY)
+        device_id = self._raw_device.get(DEVICE_ID_KEY)
+
+        # 确保 identifiers 即使在 hub_id 或 device_id 为 None 的情况下也不会出错
+        identifiers = set()
+        if hub_id and device_id:
+            identifiers.add((DOMAIN, hub_id, device_id))
+
         return DeviceInfo(
-            identifiers={
-                (DOMAIN, self._raw_device[HUB_ID_KEY], self._raw_device[DEVICE_ID_KEY])
-            },
-            name=self._raw_device[DEVICE_NAME_KEY],
+            identifiers=identifiers,
+            name=self._raw_device.get(
+                DEVICE_NAME_KEY, "Unnamed Device"
+            ),  # 安全获取名称
             manufacturer=MANUFACTURER,
-            model=self._raw_device[DEVICE_TYPE_KEY],
+            model=self._raw_device.get(DEVICE_TYPE_KEY),  # 安全获取型号
             sw_version=self._raw_device.get(DEVICE_VERSION_KEY, "unknown"),
-            via_device=(
-                (DOMAIN, self._raw_device[HUB_ID_KEY])
-                if self._raw_device[HUB_ID_KEY]
-                else None
-            ),
+            via_device=((DOMAIN, hub_id) if hub_id else None),
         )
 
     async def async_added_to_hass(self) -> None:
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,
-                f"{LIFESMART_SIGNAL_UPDATE_ENTITY}_{self.unique_id}",
+                f"{LIFESMART_SIGNAL_UPDATE_ENTITY}_{self._attr_unique_id}",
                 self._handle_update,
             )
         )
@@ -205,7 +210,7 @@ class LifeSmartCover(CoverEntity):
                 self._update_state(current_device.get(DEVICE_DATA_KEY, {}))
         except (KeyError, StopIteration):
             _LOGGER.warning(
-                "Could not find device %s during global refresh.", self.unique_id
+                "Could not find device %s during global refresh.", self._attr_unique_id
             )
 
     async def async_open_cover(self, **kwargs: Any) -> None:

--- a/custom_components/lifesmart/switch.py
+++ b/custom_components/lifesmart/switch.py
@@ -192,20 +192,25 @@ class LifeSmartSwitch(SwitchEntity):
 
     @property
     def device_info(self) -> DeviceInfo:
-        """Return device info to link entities to a single device."""
+        """返回设备信息以链接实体到单个设备。"""
+        # 从 self._raw_device 中安全地获取 hub_id 和 device_id
+        hub_id = self._raw_device.get(HUB_ID_KEY)
+        device_id = self._raw_device.get(DEVICE_ID_KEY)
+
+        # 确保 identifiers 即使在 hub_id 或 device_id 为 None 的情况下也不会出错
+        identifiers = set()
+        if hub_id and device_id:
+            identifiers.add((DOMAIN, hub_id, device_id))
+
         return DeviceInfo(
-            identifiers={
-                (DOMAIN, self._raw_device[HUB_ID_KEY], self._raw_device[DEVICE_ID_KEY])
-            },
-            name=self._raw_device[DEVICE_NAME_KEY],
+            identifiers=identifiers,
+            name=self._raw_device.get(
+                DEVICE_NAME_KEY, "Unnamed Device"
+            ),  # 安全获取名称
             manufacturer=MANUFACTURER,
-            model=self._raw_device[DEVICE_TYPE_KEY],
+            model=self._raw_device.get(DEVICE_TYPE_KEY),  # 安全获取型号
             sw_version=self._raw_device.get(DEVICE_VERSION_KEY, "unknown"),
-            via_device=(
-                (DOMAIN, self._raw_device[HUB_ID_KEY])
-                if self._raw_device[HUB_ID_KEY]
-                else None
-            ),
+            via_device=((DOMAIN, hub_id) if hub_id else None),
         )
 
     async def async_added_to_hass(self) -> None:
@@ -214,7 +219,7 @@ class LifeSmartSwitch(SwitchEntity):
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,
-                f"{LIFESMART_SIGNAL_UPDATE_ENTITY}_{self.unique_id}",
+                f"{LIFESMART_SIGNAL_UPDATE_ENTITY}_{self._attr_unique_id}",
                 self._handle_update,
             )
         )
@@ -255,7 +260,7 @@ class LifeSmartSwitch(SwitchEntity):
                     self.async_write_ha_state()
         except (KeyError, StopIteration):
             _LOGGER.warning(
-                "Could not find device %s during global refresh.", self.unique_id
+                "Could not find device %s during global refresh.", self._attr_unique_id
             )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
@@ -269,7 +274,7 @@ class LifeSmartSwitch(SwitchEntity):
         else:
             _LOGGER.warning(
                 "Failed to turn on switch %s (dev: %s, sub: %s)",
-                self.name,
+                self._attr_name,
                 self._raw_device[DEVICE_ID_KEY],
                 self._sub_key,
             )
@@ -285,7 +290,7 @@ class LifeSmartSwitch(SwitchEntity):
         else:
             _LOGGER.warning(
                 "Failed to turn off switch %s (dev: %s, sub: %s)",
-                self.name,
+                self._attr_name,
                 self._raw_device[DEVICE_ID_KEY],
                 self._sub_key,
             )

--- a/custom_components/lifesmart/switch.py
+++ b/custom_components/lifesmart/switch.py
@@ -291,6 +291,6 @@ class LifeSmartSwitch(SwitchEntity):
             _LOGGER.warning(
                 "Failed to turn off switch %s (dev: %s, sub: %s)",
                 self._attr_name,
-                self._raw_device[DEVICE_ID_KEY],
+                self._raw_device.get(DEVICE_ID_KEY, "Unknown Device ID"),
                 self._sub_key,
             )

--- a/custom_components/lifesmart/switch.py
+++ b/custom_components/lifesmart/switch.py
@@ -275,7 +275,7 @@ class LifeSmartSwitch(SwitchEntity):
             _LOGGER.warning(
                 "Failed to turn on switch %s (dev: %s, sub: %s)",
                 self._attr_name,
-                self._raw_device[DEVICE_ID_KEY],
+                self._raw_device.get(DEVICE_ID_KEY, "Unknown Device ID"),
                 self._sub_key,
             )
 


### PR DESCRIPTION
加固 __init__.py
统一并加固 device_info
统一 binary_sensor.py 的名称处理
移除冗余属性

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

fix https://github.com/MapleEve/lifesmart-for-homeassistant/issues/33#issuecomment-3093188327



#### 📝 补充信息 | Additional Information


### 数据结构分析

这是您提供的 `EpGetAll` 的完整返回：
```json
{
  "status": "ok",
  "message": [
    // 这是第一个设备
    {
      "ver": "0.0.0.11",
      "fullCls": "OD_WE_IRCTL",
      "me": "0011",
      "lHeart": 1752858435,
      "stat": 1,
      "data": { "RGB": { "type": 254, "valts": 1752858435000, "val": 16717312 } },
      "agt": "_wQBAITz658HlQAAAAAAAA",
      "devtype": "OD_WE_IRCTL",
      "agt_ver": "2.14.7.5"
    },
    // 这是第二个设备
    {
      "ver": "0.0.0.11",
      "fullCls": "OD_WE_IRCTL",
      "me": "0011",
      "lHeart": 1720855746,
      "stat": 0,
      "data": { "RGB": { "type": 254, "valts": 1720855746000, "val": 2216217728 } },
      "agt": "_wQBAITz65sOlwAAAAAAAA",
      "devtype": "OD_WE_IRCTL",
      "agt_ver": "2.14.7.5"
    }
  ],
  "code": 0,
  "id": 1752859413
}
```

现在，我们来看程序是如何处理这个数据的：
1.  程序会获取 `message` 字段的值，这是一个包含您所有设备的列表（List）。
2.  程序会遍历这个列表，对列表中的**每一个设备字典**进行处理。

让我们把第一个设备字典（也就是代码中的 `dev` 变量）单独拿出来看：
```python
dev = {
  "ver": "0.0.0.11",
  "fullCls": "OD_WE_IRCTL",
  "me": "0011",  # 这是设备ID，不是名字
  "lHeart": 1752858435,
  "stat": 1,
  "data": { ... },
  "agt": "_wQBAITz658HlQAAAAAAAA",
  "devtype": "OD_WE_IRCTL", # 这是设备型号，不是名字
  "agt_ver": "2.14.7.5"
}
```

### 关键点

当代码执行到 `self._name = dev['name']` 时，它会试图在这个字典中寻找一个键为 `'name'` 的项。

请仔细观察上面的 `dev` 字典，它的所有顶级键（key）是：
*   `ver`
*   `fullCls`
*   `me`
*   `lHeart`
*   `stat`
*   `data`
*   `agt`
*   `devtype`
*   `agt_ver`

**其中完全没有 `'name'` 这个键。**

这就是 `KeyError: 'name'` 发生的原因。程序期望在这里找到一个类似 ` "name": "我的超级碗" ` 的字段，但 LifeSmart 的 API 对于您这个型号的设备，并没有返回这个字段。

### 结论

您的日志数据非常有力地证明了：**LifeSmart API 没有为您的“超级碗（闪联版）”设备返回 `name` 字段**，导致了集成的代码在初始化设备时出错。

这再次确认了我之前给您的解决方案是正确且必要的。通过将：
`self._name = dev[DEVICE_NAME_KEY]`
修改为：
`self._name = dev.get(DEVICE_NAME_KEY, f"Unnamed {dev.get(DEVICE_TYPE_KEY, 'Device')}")`

代码的行为就会从“强制查找，找不到就崩溃”变为“尝试查找，找不到就使用一个默认名称”，从而优雅地解决了这个问题。


现在，我们的重构清单真正做到了全面和一致：

1.  **加固 `__init__.py`**：
    *   修改 `LifeSmartDevice` 的 `__init__`，安全获取所有核心属性。
    *   **状态：方案已确认。**

2.  **统一并加固 `device_info`**：
    *   在所有 6 个平台文件中，使用安全的 `.get()` 方法重写 `device_info` 属性。
    *   **状态：方案已确认。**

3.  **统一名称处理**：
    *   重构 `binary_sensor.py` 中 `LifeSmartBinarySensor` 的名称处理逻辑，使用 `_attr_name` 并移除冗余的 `name` 属性。
    *   **状态：方案已确认。**

4.  **移除所有冗余属性并统一内部调用 (最终版)**：
    *   **移除 `@property`**：
        *   在 `light.py` 和 `binary_sensor.py` 中，删除 `unique_id` 属性方法。
        *   在 `sensor.py` 中，删除 `native_value` 属性方法。
    *   **统一内部调用**：
        *   在所有 6 个平台文件中 (`light`, `switch`, `sensor`, `binary_sensor`, `cover`, `climate`)，将 `async_added_to_hass` 方法中对 `self.unique_id` 的调用改为 `self._attr_unique_id`。
        *   在 `sensor.py` 和 `binary_sensor.py` 中，将日志记录里对 `self.unique_id` 的调用也改为 `self._attr_unique_id`。
    *   **状态：本轮已确认并完善方案。**

非常感谢您的坚持和细致，这使得我们的修复方案从一个简单的 bug fix 演变成了一次高质量的代码重构。现在这份清单是完整且安全的，您可以放心地按照它来操作了。

## Sourcery 总结

通过使用字典的 `.get` 方法并提供默认值来安全地获取核心设备属性，并统一所有实体平台的命名和 `unique_id` 处理。

错误修复：
- 将针对名称、类型和 ID 的直接字典查找替换为安全的 `.get()` 调用和默认值，以防止 `KeyError` 错误。
- 当 API 未返回名称字段时，默认使用“Unnamed Device”（未命名设备）。

改进：
- 通过安全地构建 `identifiers`、`name`、`model`、`sw_version` 和 `via_device` 属性，统一跨平台的 `device_info` 构建。
- 将冗余的 `name`、`unique_id` 和 `native_value` 属性替换为 `_attr_name` 和 `_attr_unique_id` 属性。
- 在 `binary_sensor` 中添加一个 `_generate_sensor_name` 辅助函数，以标准化实体命名。
- 更新所有 `async_added_to_hass` 和更新处理程序，使其引用 `_attr_unique_id` 而不是 `unique_id`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Securely retrieve core device attributes using dictionary .get with defaults and unify naming and unique_id handling across all entity platforms.

Bug Fixes:
- Replace direct dictionary lookups for name, type, and IDs with safe .get() calls and default values to prevent KeyError.
- Default to “Unnamed Device” when the API does not return a name field.

Enhancements:
- Unify device_info construction across platforms by safely building identifiers, name, model, sw_version, and via_device attributes.
- Replace redundant name, unique_id, and native_value properties with _attr_name and _attr_unique_id attributes.
- Add a _generate_sensor_name helper in binary_sensor to standardize entity naming.
- Update all async_added_to_hass and update handlers to reference _attr_unique_id instead of unique_id.

</details>