### PR TITLE
ci: add FOSSA license scan

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -32,17 +32,8 @@ jobs:
           api-key: ${{ secrets.FOSSA_API_KEY }}
           pinned-cli-version: v3.17.1
 
-      - name: Run FOSSA diff test
-        if: ${{ env.FOSSA_API_KEY != '' && github.event_name == 'pull_request' }}
-        uses: fossas/fossa-action@v1.9.0
-        with:
-          api-key: ${{ secrets.FOSSA_API_KEY }}
-          pinned-cli-version: v3.17.1
-          run-tests: true
-          test-diff-revision: ${{ github.event.pull_request.base.sha }}
-
       - name: Run FOSSA policy test
-        if: ${{ env.FOSSA_API_KEY != '' && github.event_name != 'pull_request' }}
+        if: ${{ env.FOSSA_API_KEY != '' }}
         uses: fossas/fossa-action@v1.9.0
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -1,0 +1,50 @@
+name: FOSSA
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  fossa:
+    name: fossa
+    runs-on: ubuntu-latest
+    env:
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+    steps:
+      - name: Skip when FOSSA_API_KEY is not configured
+        if: ${{ env.FOSSA_API_KEY == '' }}
+        run: echo "FOSSA_API_KEY is not configured; skipping FOSSA scan."
+
+      - name: Checkout repository
+        if: ${{ env.FOSSA_API_KEY != '' }}
+        uses: actions/checkout@v5
+
+      - name: Run FOSSA scan
+        if: ${{ env.FOSSA_API_KEY != '' }}
+        uses: fossas/fossa-action@v1.9.0
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+          pinned-cli-version: v3.17.1
+
+      - name: Run FOSSA diff test
+        if: ${{ env.FOSSA_API_KEY != '' && github.event_name == 'pull_request' }}
+        uses: fossas/fossa-action@v1.9.0
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+          pinned-cli-version: v3.17.1
+          run-tests: true
+          test-diff-revision: ${{ github.event.pull_request.base.sha }}
+
+      - name: Run FOSSA policy test
+        if: ${{ env.FOSSA_API_KEY != '' && github.event_name != 'pull_request' }}
+        uses: fossas/fossa-action@v1.9.0
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+          pinned-cli-version: v3.17.1
+          run-tests: true


### PR DESCRIPTION
## Summary
- add a FOSSA workflow that runs policy checks on main and PRs
- reuse the existing FOSSA_API_KEY secret
- skip cleanly if the secret is absent in forks

## Validation
- workflow YAML parsed locally
- diff check passed

## Notes
- Codecov and FOSSA secrets are already configured on the repository
- existing test workflow already uploads coverage and test results to Codecov

## Summary by Sourcery

CI：
- 引入一个 FOSSA GitHub Actions 工作流，在 `main` 分支、拉取请求以及 `workflow_dispatch` 事件中运行扫描和策略检查，使用现有的 `FOSSA_API_KEY` 机密；当该机密缺失时，工作流将执行空操作（no-op）行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Introduce a FOSSA GitHub Actions workflow that runs scans and policy checks on main, pull requests, and workflow_dispatch events using the existing FOSSA_API_KEY secret, with no-op behavior when the secret is missing.

</details>
- 引入一个 FOSSA GitHub Actions 工作流程，在推送到 main、拉取请求以及手动触发时运行扫描，并在可用时使用现有的 `FOSSA_API_KEY` 机密。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI：
- 引入一个 FOSSA GitHub Actions 工作流，在 `main` 分支、拉取请求以及 `workflow_dispatch` 事件中运行扫描和策略检查，使用现有的 `FOSSA_API_KEY` 机密；当该机密缺失时，工作流将执行空操作（no-op）行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Introduce a FOSSA GitHub Actions workflow that runs scans and policy checks on main, pull requests, and workflow_dispatch events using the existing FOSSA_API_KEY secret, with no-op behavior when the secret is missing.

</details>

</details>