### PR TITLE
ci: configure Claude custom endpoint and model

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,6 +40,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GH_TOKEN }}
 
           claude_args: |
             --model ${{ env.CLAUDE_MODEL }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,6 +2,7 @@ name: Claude Code Review
 
 env:
   ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+  CLAUDE_MODEL: claude-sonnet-4-6
 
 on:
   pull_request:
@@ -36,15 +37,15 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          claude_args: |
+            --model ${{ env.CLAUDE_MODEL }}
 
           # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
+          prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices
             - Potential bugs or issues
@@ -78,4 +79,3 @@ jobs:
           # if: |
           #   !contains(github.event.pull_request.title, '[skip-review]') &&
           #   !contains(github.event.pull_request.title, '[WIP]')
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,7 +1,8 @@
 name: Claude Code
 
 env:
- ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+  ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+  CLAUDE_MODEL: claude-sonnet-4-6
 
 on:
   issue_comment:
@@ -35,16 +36,16 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-          
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+
+          claude_args: |
+            --model ${{ env.CLAUDE_MODEL }}
           
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
@@ -64,4 +65,3 @@ jobs:
           # Optional: Custom environment variables for Claude
           # claude_env: |
           #   NODE_ENV: test
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,6 +39,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GH_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary
- upgrade Claude Code workflows to anthropics/claude-code-action@v1
- keep the custom Anthropic-compatible endpoint wired through ANTHROPIC_BASE_URL
- set Claude Code and Claude Code Review to claude-sonnet-4-6 via claude_args
- migrate the automated review prompt from deprecated direct_prompt to prompt

## Validation
- git diff --check passed
- workflow YAML parsed locally
- repository secrets verified: ANTHROPIC_API_KEY and ANTHROPIC_BASE_URL exist

## Notes
- actionlint is not installed in the local environment, so GitHub Actions is the authoritative workflow validation.

## Summary by Sourcery

更新 Claude GitHub 工作流，使用稳定的 v1 Action，集中管理模型配置，并刷新代码审查提示界面。

CI：
- 将 Claude Code 和 Claude Code Review 工作流升级至 `anthropics/claude-code-action@v1`，并通过共享的 `CLAUDE_MODEL` 环境变量结合 `claude_args` 来配置模型。
- 将自动化审查配置从已废弃的 `direct_prompt` 字段迁移到新的 `prompt` 字段，同时保留原有的审查说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Claude GitHub workflows to use the stable v1 action with a centralized model configuration and refreshed review prompt interface.

CI:
- Upgrade Claude Code and Claude Code Review workflows to anthropics/claude-code-action@v1 and configure the model via a shared CLAUDE_MODEL environment variable using claude_args.
- Migrate the automated review configuration from the deprecated direct_prompt field to the new prompt field while preserving the review instructions.

</details>