### PR TITLE
ci: add HACS release packaging guardrail

### DIFF
--- a/.github/workflows/hacs-release-packaging-guardrail.yml
+++ b/.github/workflows/hacs-release-packaging-guardrail.yml
@@ -1,0 +1,34 @@
+name: HACS Release Packaging Guardrail
+
+on:
+  pull_request:
+    paths:
+      - "hacs.json"
+      - "custom_components/lifesmart/manifest.json"
+      - ".github/workflows/**"
+      - "scripts/check_hacs_release_packaging.py"
+  push:
+    branches:
+      - main
+    paths:
+      - "hacs.json"
+      - "custom_components/lifesmart/manifest.json"
+      - ".github/workflows/**"
+      - "scripts/check_hacs_release_packaging.py"
+  workflow_dispatch:
+
+jobs:
+  hacs-release-packaging-guardrail:
+    name: Prevent nested HACS release packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Validate HACS release packaging settings
+        run: python scripts/check_hacs_release_packaging.py

--- a/scripts/check_hacs_release_packaging.py
+++ b/scripts/check_hacs_release_packaging.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Guard against HACS release packaging regressions.
+
+This repository should be consumed by HACS from the GitHub source archive.
+Do not re-enable hacs.json zip_release/filename or publish a custom
+lifesmart.zip release asset unless a separate validated packaging flow is
+introduced. The v2026.05.2 incident combined those settings with a custom zip
+asset and made HACS install the integration under a nested path.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+ROOT = Path(__file__).resolve().parents[1]
+HACS_JSON = ROOT / "hacs.json"
+MANIFEST_JSON = ROOT / "custom_components" / "lifesmart" / "manifest.json"
+WORKFLOW_DIR = ROOT / ".github" / "workflows"
+RELEASE_WORKFLOW_NAMES = {"release.yml", "release.yaml"}
+FORBIDDEN_HACS_KEYS = {"zip_release", "filename"}
+FORBIDDEN_RELEASE_ASSET_PATTERNS = {
+    "lifesmart.zip": re.compile(r"lifesmart\.zip", re.IGNORECASE),
+}
+
+
+def fail(message: str) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def load_json(path: Path) -> dict:
+    try:
+        with path.open("r", encoding="utf-8") as file:
+            return json.load(file)
+    except FileNotFoundError:
+        fail(f"required file is missing: {path.relative_to(ROOT)}")
+    except json.JSONDecodeError as exc:
+        fail(f"{path.relative_to(ROOT)} is not valid JSON: {exc}")
+
+
+def iter_release_workflows() -> Iterable[Path]:
+    if not WORKFLOW_DIR.is_dir():
+        fail("required workflow directory is missing: .github/workflows")
+
+    for workflow in sorted(WORKFLOW_DIR.iterdir()):
+        if workflow.name in RELEASE_WORKFLOW_NAMES:
+            yield workflow
+
+
+def check_hacs_json() -> None:
+    hacs = load_json(HACS_JSON)
+
+    forbidden = sorted(FORBIDDEN_HACS_KEYS.intersection(hacs))
+    if forbidden:
+        fail(
+            "hacs.json must not enable custom zip releases; remove forbidden "
+            f"key(s): {', '.join(forbidden)}"
+        )
+
+    if hacs.get("content_in_root") is not False:
+        fail("hacs.json must keep content_in_root=false for custom_components/lifesmart layout")
+
+    if "homeassistant" not in hacs:
+        fail("hacs.json must declare the minimum supported Home Assistant version")
+
+
+def check_manifest_layout() -> None:
+    manifest = load_json(MANIFEST_JSON)
+
+    if manifest.get("domain") != "lifesmart":
+        fail("custom_components/lifesmart/manifest.json must declare domain=lifesmart")
+
+    if not (ROOT / "custom_components" / "lifesmart" / "__init__.py").is_file():
+        fail("custom_components/lifesmart/__init__.py is missing")
+
+
+def check_release_workflows() -> None:
+    workflows = list(iter_release_workflows())
+    if not workflows:
+        fail("release workflow is missing; keep the disabled legacy release guard in place")
+
+    for workflow in workflows:
+        text = workflow.read_text(encoding="utf-8")
+        for label, pattern in FORBIDDEN_RELEASE_ASSET_PATTERNS.items():
+            if pattern.search(text):
+                fail(
+                    f"{workflow.relative_to(ROOT)} must not publish or reference "
+                    f"a custom {label} release asset"
+                )
+
+
+def main() -> None:
+    check_hacs_json()
+    check_manifest_layout()
+    check_release_workflows()
+    print("HACS release packaging guardrail passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add a CI-backed release/HACS packaging guardrail for the LifeSmart HACS repository.
- Validate that `hacs.json` stays on the historical source-archive install path by rejecting `zip_release` and `filename`.
- Validate that the release workflow does not reference or upload a custom `lifesmart.zip` asset, preventing the nested-path HACS regression seen around v2026.05.2.
- Validate the basic `custom_components/lifesmart` manifest layout used by HACS.

v2026.05.3 has already restored the historical release mode. This PR adds the production release-process guardrail to prevent that packaging regression from returning.

Fixes #103
Fixes #104
Refs #91

## Validation
- `python3 scripts/check_hacs_release_packaging.py`
- Temporary local regression fixture with `hacs.json` containing `zip_release`/`filename` and `release.yml` referencing `lifesmart.zip` fails the guardrail as expected, then files restored and the guardrail passes again.

## Summary by Sourcery

为 LifeSmart 集成添加 CI 防护措施，以强制执行正确的 HACS 发布打包方式，并防止 HACS 安装该集成方式出现回归问题。

Enhancements:
- 添加一个 Python 脚本，用于验证 `hacs.json`、LifeSmart 的 manifest 布局以及发布工作流，确保它们符合预期的 HACS 源代码压缩包安装模型。

CI:
- 引入一个 GitHub Actions 工作流，在相关变更时运行，使用专用脚本验证 HACS 发布打包设置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a CI guardrail to enforce correct HACS release packaging for the LifeSmart integration and prevent regressions in how HACS installs the integration.

Enhancements:
- Add a Python script that validates hacs.json, the LifeSmart manifest layout, and release workflows to ensure they adhere to the expected HACS source-archive installation model.

CI:
- Introduce a GitHub Actions workflow that runs on relevant changes to validate HACS release packaging settings using a dedicated script.

</details>