### PR TITLE
ci: tighten Codecov coverage gates

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,8 +7,10 @@ coverage:
     project:
       default:
         informational: false
-        target: 70%           # 目标覆盖率
+        target: 90%           # 目标覆盖率
+        threshold: 0%
     patch:
       default:
         informational: false
-        target: 60%
+        target: 80%
+        threshold: 0%


### PR DESCRIPTION
## Summary
- set Codecov project coverage gate to 90%
- set Codecov patch coverage gate to 80%
- set threshold tolerance to 0% for both gates

## Validation
- codecov.yml parsed locally
- git diff --check passed

## Note
If current project coverage is below 90%, the Codecov project check should fail by design until coverage is raised.

## Summary by Sourcery

提高 Codecov 对项目和补丁检查的覆盖率要求，并强制执行零容差阈值。

Build:
- 将 Codecov 项目覆盖率目标从 70% 提高到 90%，并将阈值容差设为 0%。
- 将 Codecov 补丁覆盖率目标从 60% 提高到 80%，以收紧对每次变更的覆盖率门控。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Raise Codecov coverage requirements for both project and patch checks and enforce zero-tolerance thresholds.

Build:
- Increase Codecov project coverage target from 70% to 90% with a 0% threshold tolerance.
- Increase Codecov patch coverage target from 60% to 80% to tighten per-change coverage gating.

</details>