### PR TITLE
ci: always post Claude review summary

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,7 +1,9 @@
 name: Claude Code Review
 
 env:
+  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+  GH_TOKEN_VALUE: ${{ secrets.GH_TOKEN }}
   CLAUDE_MODEL: claude-sonnet-4-6
 
 on:
@@ -25,18 +27,25 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
     
     steps:
+      - name: Skip when Claude secrets are not configured
+        if: ${{ env.ANTHROPIC_API_KEY == '' || env.ANTHROPIC_BASE_URL == '' || env.GH_TOKEN_VALUE == '' }}
+        run: echo "Claude Code review secrets are not configured; skipping Claude Code Review."
+
       - name: Checkout repository
+        if: ${{ env.ANTHROPIC_API_KEY != '' && env.ANTHROPIC_BASE_URL != '' && env.GH_TOKEN_VALUE != '' }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
+        if: ${{ env.ANTHROPIC_API_KEY != '' && env.ANTHROPIC_BASE_URL != '' && env.GH_TOKEN_VALUE != '' }}
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -80,3 +89,37 @@ jobs:
           # if: |
           #   !contains(github.event.pull_request.title, '[skip-review]') &&
           #   !contains(github.event.pull_request.title, '[WIP]')
+
+      - name: Post Claude Code Review summary
+        if: ${{ always() && github.event_name == 'pull_request' && env.ANTHROPIC_API_KEY != '' && env.ANTHROPIC_BASE_URL != '' && env.GH_TOKEN_VALUE != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CLAUDE_OUTCOME: ${{ steps.claude-review.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          MARKER: "<!-- claude-code-review-summary -->"
+        run: |
+          set -euo pipefail
+          short_sha="${HEAD_SHA:0:7}"
+          if [ "$CLAUDE_OUTCOME" = "success" ]; then
+            body="$(printf '%s\n### Claude Code Review\n\nClaude Code Review completed for `%s`.\n\nThis summary is posted even when Claude has no line-level findings. If no separate Claude inline comments are visible, there were no actionable line-level findings for this run.\n\nRun: %s' "$MARKER" "$short_sha" "$RUN_URL")"
+          else
+            body="$(printf '%s\n### Claude Code Review\n\nClaude Code Review did not complete successfully for `%s`.\n\nCheck the workflow run before merging. The check will remain failed so this cannot be missed.\n\nRun: %s' "$MARKER" "$short_sha" "$RUN_URL")"
+          fi
+
+          comment_id="$(
+            gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --paginate \
+              --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" | tail -n 1
+          )"
+          if [ -n "$comment_id" ]; then
+            jq -n --arg body "$body" '{body: $body}' \
+              | gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" --input -
+          else
+            jq -n --arg body "$body" '{body: $body}' \
+              | gh api -X POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --input -
+          fi
+
+      - name: Fail when Claude Code Review failed
+        if: ${{ steps.claude-review.outcome == 'failure' }}
+        run: exit 1


### PR DESCRIPTION
## Summary
- make automated Claude Code Review always post or update a PR-level summary comment
- keep the Claude check failing when the review action fails
- grant explicit PR review and issue comment write permissions

## Verification
- YAML parsed locally
- git diff --check passed

## 由 Sourcery 提供的总结

确保 Claude Code Review 工作流在对缺失密钥保持敏感的同时，总是发布一个 PR 级别的总结评论，并在审查失败时保留失败状态。

CI：
- 在 Claude Code Review 工作流中要求配置 Anthropic 和 GitHub 令牌，并在未配置时优雅地跳过执行。
- 授予对拉取请求和问题（issues）的写入权限，以便工作流可以创建或更新总结评论。
- 添加一个步骤，在每次运行时发布或更新单个 PR 级别的 Claude 审查总结评论，并在审查步骤失败时保持该任务标记为失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

确保 Claude Code Review 工作流在评审操作失败时，始终发布或更新 PR 级别的总结评论，同时保持失败状态。

CI：
- 要求为 Claude Code Review 工作流配置 Anthropic 和 GitHub 令牌；当未配置时跳过执行。
- 将拉取请求和问题（issue）的权限提升为写入，以便工作流可以管理总结评论。
- 添加一步，在每次运行时创建或更新单一的 PR 级 Claude 评审总结评论，并在评审步骤失败时保持该任务标记为失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure the Claude Code Review workflow always posts or updates a PR-level summary comment while preserving a failing status when the review action fails.

CI:
- Require Anthropic and GitHub tokens for the Claude Code Review workflow and skip execution when they are not configured.
- Elevate pull request and issue permissions to write so the workflow can manage summary comments.
- Add a step to create or update a single PR-level Claude review summary comment on every run and keep the job marked as failed when the review step fails.

</details>

</details>

CI：
- 配置 Claude Code Review 工作流程以要求提供 Anthropic 和 GitHub 令牌，并在它们缺失时优雅地跳过执行。
- 授予对拉取请求（pull requests）和问题（issues）的写入权限，以便该工作流程可以发布或更新总结评论。
- 添加一个步骤，在每次运行时发布或更新单个 PR 级别的 Claude 评审总结评论，并在评审步骤失败时保持该任务（job）处于失败状态。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

确保 Claude Code Review 工作流在对缺失密钥保持敏感的同时，总是发布一个 PR 级别的总结评论，并在审查失败时保留失败状态。

CI：
- 在 Claude Code Review 工作流中要求配置 Anthropic 和 GitHub 令牌，并在未配置时优雅地跳过执行。
- 授予对拉取请求和问题（issues）的写入权限，以便工作流可以创建或更新总结评论。
- 添加一个步骤，在每次运行时发布或更新单个 PR 级别的 Claude 审查总结评论，并在审查步骤失败时保持该任务标记为失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

确保 Claude Code Review 工作流在评审操作失败时，始终发布或更新 PR 级别的总结评论，同时保持失败状态。

CI：
- 要求为 Claude Code Review 工作流配置 Anthropic 和 GitHub 令牌；当未配置时跳过执行。
- 将拉取请求和问题（issue）的权限提升为写入，以便工作流可以管理总结评论。
- 添加一步，在每次运行时创建或更新单一的 PR 级 Claude 评审总结评论，并在评审步骤失败时保持该任务标记为失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure the Claude Code Review workflow always posts or updates a PR-level summary comment while preserving a failing status when the review action fails.

CI:
- Require Anthropic and GitHub tokens for the Claude Code Review workflow and skip execution when they are not configured.
- Elevate pull request and issue permissions to write so the workflow can manage summary comments.
- Add a step to create or update a single PR-level Claude review summary comment on every run and keep the job marked as failed when the review step fails.

</details>

</details>

</details>