### PR TITLE
fix(protocol): pack numeric enum ids in _pack_value (fixes local setup)

### DIFF
--- a/custom_components/lifesmart/core/protocol.py
+++ b/custom_components/lifesmart/core/protocol.py
@@ -153,6 +153,13 @@ class LifeSmartProtocol:
                 enum_id = self.REVERSE_KEY_MAPPING.get(key)
                 if enum_id is not None:
                     return struct.pack("BB", 0x13, enum_id)
+                # 数字 enum id (例如 "enum:91")：直接打包为 int，避免 get-config
+                # 等动作中数字字段（act="enum:91" 等）被错误地按字符串编码后被网关
+                # 以 ENADF1 拒绝。仅当 key 是合法整数时生效。
+                try:
+                    return struct.pack("BB", 0x13, int(key))
+                except (ValueError, struct.error):
+                    pass
                 # 如果没有找到对应的enum_id，则作为普通字符串处理
                 return self._string_to_bin(value)
             if isKey and self.REVERSE_KEY_MAPPING.get(value):

--- a/custom_components/lifesmart/tests/test_protocol.py
+++ b/custom_components/lifesmart/tests/test_protocol.py
@@ -245,6 +245,28 @@ class TestProtocolSpecialTypes:
 
         assert decoded_message == normal_message, "不含enum前缀的字典应该保持不变"
 
+    def test_enum_numeric_id_packing(self, protocol: LifeSmartProtocol):
+        """回归测试：数字 enum id（例如 "enum:91"）必须被打包为 0x13 + 单字节 int。
+
+        get-config 等本地动作使用 act="enum:91"、嵌套字段使用 "enum:14"/"enum:98"
+        等数字 id。这些 id 不在 REVERSE_KEY_MAPPING 中，若被退化为
+        _string_to_bin("enum:91")，本地网关会返回 ENADF1 拒绝并使集成在
+        ConfigEntryNotReady 处启动失败（参见 issues #117 / #119）。
+        """
+        # 单字节范围内的数字 enum id 应打包为 0x13 + 单字节
+        assert protocol._pack_value("enum:91") == b"\x13\x5b"
+        assert protocol._pack_value("enum:14") == b"\x13\x0e"
+        assert protocol._pack_value("enum:0") == b"\x13\x00"
+        assert protocol._pack_value("enum:255") == b"\x13\xff"
+
+        # 在 REVERSE_KEY_MAPPING 中的命名 enum 仍走映射路径，行为不变
+        # 例：'val' -> 41 (0x29)
+        assert protocol._pack_value("enum:val") == b"\x13\x29"
+
+        # 非数字、未映射的 enum 字符串不应抛出异常，应退化为普通字符串编码
+        bogus = protocol._pack_value("enum:notanumber")
+        assert bogus[0] == 0x11  # _string_to_bin 类型头
+
     def test_special_null_handling(self, protocol: LifeSmartProtocol):
         """测试特殊NULL值的处理。"""
         test_cases = [


### PR DESCRIPTION
## Summary

`LifeSmartProtocol._pack_value` only emits `0x13 + int` when the suffix after `enum:` is a **named** key in `REVERSE_KEY_MAPPING`. **Numeric** enum ids — `act="enum:91"` used by `build_get_config_packet`, plus `"enum:14"` / `"enum:98"` / `"enum:12"` / `"enum:13"` in nested args — fall through to `_string_to_bin` and get packed as the literal UTF-8 string `"enum:91"`. The local gateway then replies `err: 'ENADF1:<node>/me/ep:enum:91'` and the integration aborts with `ConfigEntryNotReady("从本地网关获取设备列表失败。")` at `hub.py:246`, so local mode never finishes setup on real hubs.

This is the regression behind the open setup-failure reports in #117 and #119. Login bytes are unaffected (login uses no numeric enum ids), which is why the connection appears to authenticate but then the very next `get_config` round-trip fails.

## Fix

Inside the existing `if value.startswith("enum:"):` branch, after the named-mapping lookup, add a numeric fallback: try `int(key)` and pack as `0x13 + single byte`. Non-numeric, unmapped enum strings still fall back to `_string_to_bin` as before, so this is purely additive.

```python
if value.startswith("enum:"):
    key = value[5:]
    enum_id = self.REVERSE_KEY_MAPPING.get(key)
    if enum_id is not None:
        return struct.pack("BB", 0x13, enum_id)
    # NEW: numeric enum id (e.g. "enum:91") — pack as int
    try:
        return struct.pack("BB", 0x13, int(key))
    except (ValueError, struct.error):
        pass
    return self._string_to_bin(value)
```

This restores the v25.07.30.RC encoding for these acts, which is what the local gateway accepts.

## Why the existing test missed it

`test_enum_key_normalization` exercises `encode` → `decode` round-trips with `enum:device_type` / `enum:status`. Neither of those keys is in `REVERSE_KEY_MAPPING`, so encode silently produces literal strings — but the decoder strips the `enum:` prefix on the return trip regardless of how it was packed, so the assertion still passes. The new `test_enum_numeric_id_packing` calls `_pack_value` directly and asserts the actual on-the-wire bytes (`b"\x13\x5b"` for `enum:91`, etc.), which would have caught this regression at PR time.

## Verified against a real hub

Patched in place on a live Smart Station (firmware as of 2026-05) and the local config entry came back with the full device list — 6 `SL_NATURE` climates + 12 `SL_SW_IF1/2` switches reporting real states instead of `unavailable`.

## Test plan

- [x] `_pack_value("enum:91")` returns `b"\x13\x5b"` (verified in isolation)
- [x] Named-mapping path unchanged: `_pack_value("enum:val")` returns `b"\x13\x29"` (val → 41)
- [x] Non-numeric unmapped path falls back to string encoding without raising
- [x] Real hub: get-config succeeds after the patch; entities populate

Refs #117, #119.
