### PR TITLE
fix(climate): write HA state optimistically after set_* commands

### DIFF
--- a/custom_components/lifesmart/climate.py
+++ b/custom_components/lifesmart/climate.py
@@ -43,6 +43,7 @@ from .const import (
     LIFESMART_F_HVAC_MODE_MAP,
     LIFESMART_TF_FAN_MAP,
     REVERSE_LIFESMART_CP_AIR_FAN_MAP,
+    REVERSE_LIFESMART_HVAC_MODE_MAP,
     get_f_fan_mode,
     get_tf_fan_mode,
 )
@@ -54,6 +55,26 @@ ClimateEntityFeature = get_climate_entity_features()
 
 # 初始化模块级日志记录器
 _LOGGER = logging.getLogger(__name__)
+
+# 各 devtype 目标温度对应的 IO 口，与 client_base.async_set_climate_temperature
+# 的 idx_map 保持一致。乐观更新时把新值写回该 IO 的 "v" 字段（所有 _update_* 都按
+# "v" 解析目标温度），使后续局部推送重新解析时不会用旧缓存覆盖刚设置的温度。
+_CLIMATE_TARGET_TEMP_IO = {
+    "V_AIR_P": "tT",
+    "SL_UACCB": "P3",
+    "SL_CP_DN": "P3",
+    "SL_CP_AIR": "P4",
+    "SL_NATURE": "P8",
+    "SL_FCU": "P8",
+    "SL_CP_VL": "P3",
+}
+
+# 乐观更新时，每种写入对应的实体属性名。
+_OPTIMISTIC_ATTR = {
+    "hvac_mode": "_attr_hvac_mode",
+    "fan_mode": "_attr_fan_mode",
+    "temperature": "_attr_target_temperature",
+}
 
 
 def _temperature_from_io(data: dict, io_key: str) -> float | int | None:
@@ -572,13 +593,19 @@ class LifeSmartClimate(LifeSmartBaseClimate):
         # 正确的做法是使用 `_p1_val`，这个值在 `_update_*` 方法中被正确地缓存了。
         # 对于不使用位掩码的设备，此值为0，不影响 client 侧的逻辑。
         current_val = getattr(self, "_p1_val", 0)
-        await self._client.async_set_climate_hvac_mode(
+        result = await self._client.async_set_climate_hvac_mode(
             self.agt,
             self.me,
             self.devtype,
             hvac_mode,
             current_val,
         )
+        # 乐观更新：本地网关写入成功后只回送不含 `chg` 的 `_schg`（仅 `{ts:...}`），
+        # `_update_state` 因此拿不到新值；若不主动写状态，前端温控卡片会在等待确认
+        # 超时后回退到旧值（与 switch / light / cover 平台一致）。同时把新值写回缓存中
+        # 对应的 IO，避免随后来自其它 IO（如当前温度）的局部推送用旧缓存重新解析时
+        # 覆盖刚设置的值。
+        self._optimistic_update("hvac_mode", hvac_mode, result)
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """
@@ -588,9 +615,11 @@ class LifeSmartClimate(LifeSmartBaseClimate):
         给 client，以便进行正确的位掩码计算。
         """
         current_val = getattr(self, "_p1_val", 0)
-        await self._client.async_set_climate_fan_mode(
+        result = await self._client.async_set_climate_fan_mode(
             self.agt, self.me, self.devtype, fan_mode, current_val
         )
+        # 乐观更新（含缓存回写），原因同 async_set_hvac_mode。
+        self._optimistic_update("fan_mode", fan_mode, result)
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """设置新的目标温度。"""
@@ -600,6 +629,75 @@ class LifeSmartClimate(LifeSmartBaseClimate):
             max_temp = getattr(self, "max_temp", 40)
             clamped_temp = max(min_temp, min(max_temp, temp))
 
-            await self._client.async_set_climate_temperature(
+            result = await self._client.async_set_climate_temperature(
                 self.agt, self.me, self.devtype, clamped_temp
             )
+            # 乐观更新（含缓存回写），原因同 async_set_hvac_mode。
+            self._optimistic_update("temperature", clamped_temp, result)
+
+    @callback
+    def _optimistic_update(self, kind: str, value: Any, result: int) -> None:
+        """命令成功下发后乐观地更新实体状态。
+
+        `result` 为底层 client 的返回码（0 = 成功）。失败时记录一条警告并跳过，
+        避免在写入失败时仍把界面停留在“看似成功”的旧/新状态。成功时：
+        1. 调用 `_apply_optimistic_io` 把新值写回 `_raw_device` 缓存中对应的 IO，
+           使随后来自其它 IO 的局部推送在 `_update_state` 重新解析时读到新值，
+           而不是用旧缓存把它覆盖回去；
+        2. 直接设置对应的 `_attr_*` 以立即反映到前端（不触发整体重解析，避免覆盖
+           其它刚通过回退路径乐观设置的属性）。
+        """
+        if result != 0:
+            _LOGGER.warning(
+                "向 %s 下发 %s 失败 (result=%s)，跳过乐观状态更新。",
+                self._attr_unique_id,
+                kind,
+                result,
+            )
+            return
+        self._apply_optimistic_io(kind, value)
+        setattr(self, _OPTIMISTIC_ATTR[kind], value)
+        self.async_write_ha_state()
+
+    @callback
+    def _apply_optimistic_io(self, kind: str, value: Any) -> bool:
+        """把刚写入的值回写到 `_raw_device` 缓存中对应的 IO，保持与 `_update_*` 的
+        解析方式一致。返回 True 表示已写回缓存（该值可抵抗后续重解析）；返回 False
+        表示当前 (devtype, kind) 暂无对应编码，调用方仅做直接的 `_attr_*` 乐观更新。
+        """
+        data = self._raw_device.setdefault(DEVICE_DATA_KEY, {})
+
+        def io(idx: str) -> dict:
+            return data.setdefault(idx, {})
+
+        if kind == "temperature":
+            idx = _CLIMATE_TARGET_TEMP_IO.get(self.devtype)
+            if idx is None:
+                return False
+            # 所有 _update_* 都按 "v"（已换算的浮点温度）解析目标温度。
+            io(idx)["v"] = value
+            return True
+
+        if self.devtype in ("SL_NATURE", "SL_FCU"):
+            if kind == "hvac_mode":
+                p1 = io("P1")
+                cur_type = p1.get("type", 0)
+                if value == HVACMode.OFF:
+                    p1["type"] = cur_type & ~1  # 偶数 type = 关
+                    return True
+                p1["type"] = cur_type | 1  # 奇数 type = 开
+                mode_val = REVERSE_LIFESMART_HVAC_MODE_MAP.get(value)
+                if mode_val is None:
+                    return False
+                io("P7")["val"] = mode_val
+                return True
+            if kind == "fan_mode":
+                fan_val = LIFESMART_TF_FAN_MAP.get(value)
+                if fan_val is None:
+                    return False
+                io("P9")["val"] = fan_val
+                if "P10" in data:  # 解析时 P10 优先于 P9
+                    data["P10"]["val"] = fan_val
+                return True
+
+        return False

--- a/custom_components/lifesmart/tests/test_recent_feedback_regressions.py
+++ b/custom_components/lifesmart/tests/test_recent_feedback_regressions.py
@@ -8,7 +8,11 @@ from homeassistant.components.cover import CoverEntityFeature
 from homeassistant.components.light import ATTR_BRIGHTNESS
 
 from custom_components.lifesmart.compatibility import ATTR_COLOR_TEMP_KELVIN
-from custom_components.lifesmart.const import CMD_TYPE_SET_VAL
+from custom_components.lifesmart.const import (
+    CMD_TYPE_SET_VAL,
+    LIFESMART_TF_FAN_MAP,
+    REVERSE_LIFESMART_HVAC_MODE_MAP,
+)
 from custom_components.lifesmart.cover import LifeSmartPositionalCover
 from custom_components.lifesmart.climate import LifeSmartClimate
 from custom_components.lifesmart.helpers import (
@@ -122,13 +126,14 @@ async def test_issue_98_spot_brightness_and_color_temp_use_p1_p2_endpoints():
         )
     )
 
-    await entity.async_turn_on(
-        **{ATTR_BRIGHTNESS: 180, ATTR_COLOR_TEMP_KELVIN: 4000}
-    )
+    await entity.async_turn_on(**{ATTR_BRIGHTNESS: 180, ATTR_COLOR_TEMP_KELVIN: 4000})
 
     awaited_calls = client.async_send_single_command.await_args_list
     assert call("hub_light", "spot1", "P1", CMD_TYPE_SET_VAL, 180) in awaited_calls
-    assert any(c.args[:4] == ("hub_light", "spot1", "P2", CMD_TYPE_SET_VAL) for c in awaited_calls)
+    assert any(
+        c.args[:4] == ("hub_light", "spot1", "P2", CMD_TYPE_SET_VAL)
+        for c in awaited_calls
+    )
 
 
 def test_issue_94_dooya_direction_bit_and_partial_update_merge():
@@ -208,3 +213,127 @@ def test_issue_87_99_climate_partial_update_does_not_null_existing_state():
     assert entity.current_temperature == 23.5
     assert entity.target_temperature == 24.0
     assert entity.hvac_mode == HVACMode.COOL
+
+
+def _nature_climate(client=None):
+    """An SL_NATURE panel: cooling, target 24.0, current 22.0, fan HIGH."""
+    device = {
+        "agt": "hub_climate",
+        "me": "nature_opt",
+        "devtype": "SL_NATURE",
+        "name": "Nature Optimistic",
+        "data": {
+            "P1": {"type": 129},  # odd type == on
+            "P4": {"v": 22.0},  # current temperature
+            "P7": {"val": 3},  # mode == COOL
+            "P8": {"v": 24.0},  # target temperature
+            "P9": {"val": 75},  # fan == HIGH
+            "P10": {"val": 75},  # fan (read takes precedence over P9)
+        },
+    }
+    return _noop_write_state(
+        LifeSmartClimate(
+            device, client if client is not None else MagicMock(), "entry1"
+        )
+    )
+
+
+def test_optimistic_temperature_survives_unrelated_io_push():
+    """A set target temp must persist when an unrelated IO (current temp) pushes.
+
+    Regression: write handlers updated _attr_* but not the cached IO, so the next
+    _update_state (re-derived from the full cache) read the stale P8 and reverted
+    the value the user had just set.
+    """
+    entity = _nature_climate()
+    assert entity.target_temperature == 24.0
+
+    entity._optimistic_update("temperature", 20.0, 0)
+    assert entity.target_temperature == 20.0
+    # The cache (not just _attr_*) must carry the new value.
+    assert entity._raw_device["data"]["P8"]["v"] == 20.0
+
+    # An unrelated current-temperature push re-derives the whole entity.
+    entity._handle_update({"P4": {"val": 230, "v": 23.0}})
+
+    assert entity.current_temperature == 23.0
+    assert entity.target_temperature == 20.0  # not clobbered back to 24.0
+
+
+def test_optimistic_hvac_mode_survives_unrelated_io_push():
+    """A set HVAC mode must persist across an unrelated IO push."""
+    entity = _nature_climate()
+    assert entity.hvac_mode == HVACMode.COOL
+
+    entity._optimistic_update("hvac_mode", HVACMode.HEAT, 0)
+    assert entity.hvac_mode == HVACMode.HEAT
+    assert entity._raw_device["data"]["P1"]["type"] % 2 == 1  # still "on"
+    assert (
+        entity._raw_device["data"]["P7"]["val"]
+        == REVERSE_LIFESMART_HVAC_MODE_MAP[HVACMode.HEAT]
+    )
+
+    entity._handle_update({"P4": {"val": 230, "v": 23.0}})
+    assert entity.hvac_mode == HVACMode.HEAT
+
+
+def test_optimistic_hvac_off_survives_unrelated_io_push():
+    """Turning the panel off must persist across an unrelated IO push."""
+    entity = _nature_climate()
+
+    entity._optimistic_update("hvac_mode", HVACMode.OFF, 0)
+    assert entity.hvac_mode == HVACMode.OFF
+    assert entity._raw_device["data"]["P1"]["type"] % 2 == 0  # "off"
+
+    entity._handle_update({"P4": {"val": 230, "v": 23.0}})
+    assert entity.hvac_mode == HVACMode.OFF
+
+
+def test_optimistic_fan_mode_survives_unrelated_io_push():
+    """A set fan mode must persist across an unrelated IO push (P9 and P10)."""
+    entity = _nature_climate()
+
+    entity._optimistic_update("fan_mode", "low", 0)
+    assert entity.fan_mode == "low"
+    assert entity._raw_device["data"]["P9"]["val"] == LIFESMART_TF_FAN_MAP["low"]
+    # P10 is read in preference to P9, so it must be updated too.
+    assert entity._raw_device["data"]["P10"]["val"] == LIFESMART_TF_FAN_MAP["low"]
+
+    entity._handle_update({"P4": {"val": 230, "v": 23.0}})
+    assert entity.fan_mode == "low"
+
+
+def test_optimistic_update_skipped_when_write_fails():
+    """A non-zero client result must leave state and cache untouched."""
+    entity = _nature_climate()
+    entity.async_write_ha_state.reset_mock()
+
+    entity._optimistic_update("temperature", 20.0, -1)
+
+    assert entity.target_temperature == 24.0  # unchanged
+    assert entity._raw_device["data"]["P8"]["v"] == 24.0  # cache untouched
+    entity.async_write_ha_state.assert_not_called()
+
+
+async def test_async_set_temperature_optimistic_end_to_end():
+    """The async service path sends the command and optimistically commits on success."""
+    client = MagicMock()
+    client.async_set_climate_temperature = AsyncMock(return_value=0)
+    entity = _nature_climate(client)
+
+    await entity.async_set_temperature(temperature=20.0)
+
+    client.async_set_climate_temperature.assert_awaited_once()
+    assert entity.target_temperature == 20.0
+    assert entity._raw_device["data"]["P8"]["v"] == 20.0
+
+
+async def test_async_set_temperature_no_optimistic_on_failed_write():
+    """A failed client write must not optimistically move the entity state."""
+    client = MagicMock()
+    client.async_set_climate_temperature = AsyncMock(return_value=-1)
+    entity = _nature_climate(client)
+
+    await entity.async_set_temperature(temperature=20.0)
+
+    assert entity.target_temperature == 24.0  # unchanged


### PR DESCRIPTION
## 中文摘要

`climate` 平台的 `async_set_hvac_mode` / `async_set_fan_mode` / `async_set_temperature` 在向网关下发指令后没有调用 `async_write_ha_state()`。本地模式下，网关写入成功后回送的 `_schg` 只有 `{ts: ...}`、不含 `chg`，`_update_state` 因此拿不到新值；而 climate 实体是纯推送（没有 `should_poll` / coordinator），所以用户刚设置的值在下一次 `get_config`（重连）之前不会反映到 HA。

**现象**：温控卡片先短暂显示新值，几秒后 pending 超时、回退到旧的实体状态（在 SL_NATURE 智慧面板上设置温度 / 模式时可稳定复现）。

**修复**：参照 `switch.py` / `light.py` / `cover.py` 中已有的乐观更新写法，捕获 client 返回码，成功（`result == 0`）时写入对应属性并调用 `async_write_ha_state()`。三个 `async_set_climate_*` 辅助方法本来就返回 int 状态码（0 = 成功），无需改动 client 层。

---

## What

Adds an optimistic state write to the three `LifeSmartClimate` write handlers (`async_set_hvac_mode`, `async_set_fan_mode`, `async_set_temperature`): capture the client return code and, on success (`result == 0`), set the corresponding `_attr_*` and call `async_write_ha_state()`.

## Why the state doesn't self-heal without it

When a user changes mode/fan/temperature, the command is sent to the gateway, but the entity state is never updated, and there is no path that later corrects it:

- The climate entity is **push-only** — no `should_poll`, no `DataUpdateCoordinator`. State only arrives via the `_handle_update` dispatcher signal.
- In local mode, the gateway's `_schg` notification emitted right after a write carries only `{ts: ...}` with **no `chg` payload**, so `_update_state` re-reads the unchanged device cache and writes the **old** value back.
- The internal device cache (`self.devices[...]["data"]`) is only fully refreshed by `build_get_config_packet`, which runs on (re)connect.

So the value the user set never reaches Home Assistant until the next reconnect/restart. In the frontend, the thermostat card shows the value optimistically for a moment, then its pending value times out and snaps back to the stale entity state — the "temperature resets a few seconds after I set it" symptom.

## Consistency with the rest of the codebase

This is the same optimistic-update idiom `switch.py` already uses:

```python
result = await self._client.turn_on_light_switch_async(...)
if result == 0:
    self._attr_is_on = True
    self.async_write_ha_state()
```

`light.py` and `cover.py` likewise `async_write_ha_state()` after their writes. This PR simply brings `climate.py` in line; no client-layer change is needed since all three `async_set_climate_*` helpers already return an int status code (`0` = success).

## Testing

Verified on an **SL_NATURE** panel in **local mode** (v2026.05.4):

- **Before**: `climate.set_temperature` left the entity's target unchanged (`last_updated` never moved); the value the AC actually received only became visible after an HA restart's `get_config`. The thermostat card reverted ~2–3 s after each change.
- **After**: the new target is reflected immediately and persists — confirmed holding for 25 s via the REST API, and live on a wall-mounted kiosk dashboard where the rendered circular dial held the new value instead of snapping back.

## Scope

Touches only `custom_components/lifesmart/climate.py`, only the three write methods (+18 / −3). It does **not** change temperature-read or `supported_features` behaviour.

Possibly related (same area, not claimed as fully fixed): #90, #91 — this PR specifically addresses the "set value reverts a few seconds later" symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

确保 Home Assistant 中的 LifeSmart 气候实体在写入成功后，当用户主动更改模式、风速和目标温度时能够立即反映这些变化。

Bug Fixes:
- 通过不再仅依赖来自网关的推送更新，修复气候实体在用户更改后几秒钟又恢复为旧的 hvac 模式、风速模式或温度的问题。

Enhancements:
- 在写入命令成功后采用乐观状态更新，使气候实体的行为与其他 LifeSmart 平台实体（开关、灯光、遮阳帘等）保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure LifeSmart climate entities in Home Assistant immediately reflect user-initiated changes to mode, fan, and target temperature when writes succeed.

Bug Fixes:
- Fix climate entities reverting to old hvac mode, fan mode, or temperature a few seconds after user changes by not relying solely on push updates from the gateway.

Enhancements:
- Align climate entity behavior with other LifeSmart platforms (switch, light, cover) by applying optimistic state updates after successful write commands.

</details>