### PR TITLE
fix(protocol): decode 0x05 as IEEE 754 64-bit float (Double) instead of hex

### DIFF
--- a/custom_components/lifesmart/core/protocol.py
+++ b/custom_components/lifesmart/core/protocol.py
@@ -139,6 +139,9 @@ class LifeSmartProtocol:
         if isinstance(value, bool):  # 处理布尔值
             return b"\x02" if value else b"\x03"
 
+        if isinstance(value, float):  # 处理浮点数 (64位 IEEE 754 Double)
+            return b"\x05" + struct.pack(">d", value)
+
         if isinstance(value, int):  # 处理整数
             if not -0x80000000 <= value <= 0x7FFFFFFF:
                 raise ValueError(f"int 超出 32-bit 有符号范围: {value}")
@@ -230,17 +233,11 @@ class LifeSmartProtocol:
                 zz = self._decode_varint(stream)
                 return (zz >> 1) ^ -(zz & 1)  # 反 ZigZag
 
-            if data_type == 0x05:  # HEX类型处理
-                index = stream.read(1)[0]
-                hex_data = stream.read(8)
-                if len(hex_data) < 8:
-                    raise EOFError("HEX 数据不完整")
-                return {
-                    "type": "HEX",
-                    "index": index,
-                    "value": hex_data.hex(),
-                    "raw": hex_data,
-                }
+            elif data_type == 0x05:  # 64位浮点数 (Double IEEE 754)
+                raw_bytes = stream.read(8)
+                if len(raw_bytes) < 8:
+                    raise EOFError("Float 数据不完整")
+                return struct.unpack(">d", raw_bytes)[0]
 
             elif data_type == 0x06:  # 时间戳类型处理
                 index = stream.read(1)[0]

--- a/custom_components/lifesmart/tests/test_protocol.py
+++ b/custom_components/lifesmart/tests/test_protocol.py
@@ -90,6 +90,9 @@ class TestProtocolDataTypeEncoding:
             ("ListMixed", [1, True, "test", None]),
             ("DictEmpty", {}),
             ("DictSimple", {"key": "value", "number": 42}),
+            ("FloatPositive", 71.8),
+            ("FloatNegative", -2.5),
+            ("FloatZero", 0.0),
             ("SpecialNull", "::NULL::"),
         ],
     )
@@ -467,13 +470,13 @@ class TestProtocolErrorHandling:
         with pytest.raises(EOFError, match="字符串数据不足"):
             protocol._parse_value(BytesIO(incomplete_string_data), 0x11)  # 字符串类型码
 
-    def test_incomplete_hex_data(self, protocol: LifeSmartProtocol):
-        """测试十六进制数据不完整的情况。"""
-        # 模拟HEX数据不完整（需要8字节但只有4字节）
-        incomplete_hex_data = b"\x01\x11\x22\x33"
+    def test_incomplete_float_data(self, protocol: LifeSmartProtocol):
+        """测试浮点数数据不完整的情况。"""
+        # 模拟Float数据不完整（需要8字节但只有4字节）
+        incomplete_float_data = b"\x01\x11\x22\x33"
 
-        with pytest.raises(EOFError, match="HEX 数据不完整"):
-            protocol._parse_value(BytesIO(incomplete_hex_data), 0x05)  # HEX类型码
+        with pytest.raises(EOFError, match="Float 数据不完整"):
+            protocol._parse_value(BytesIO(incomplete_float_data), 0x05)  # 浮点数类型码
 
     def test_incomplete_timestamp_data(self, protocol: LifeSmartProtocol):
         """测试时间戳数据不完整的情况。"""


### PR DESCRIPTION
## Description

### Problem
When decoding LifeSmart binary packets from gateways with sensors reporting float values (such as humidity `71.8%` or battery voltage `2.7V`), type code `0x05` was previously parsed as a 1-byte index followed by 8 bytes hex (9 bytes total).
This consumed 1 extra byte from the stream and shifted all subsequent stream pointers, resulting in warnings (`未知的解码数据类型: 0x79, 0x70, 0x65`) and failing to parse large device lists (`EOFError: 解析第...个键时数据流提前结束`).

### Solution
- Decode `0x05` as standard IEEE 754 64-bit float (`>d`, 8 bytes total) via `struct.unpack(">d", stream.read(8))[0]`.
- Add `float` packing support in `_pack_value`.
- Update unit tests in `test_protocol.py` to cover float roundtrip and error handling.

## Sourcery 摘要

修正浮点值的解码和编码，以保持数据包对齐，并可靠地支持传感器数据。

错误修复：
- 将协议类型 0x05 解码为 IEEE 754 64 位浮点值，防止解析传感器数据时出现流错位。

增强功能：
- 为协议值添加浮点数序列化支持。

测试：
- 扩展协议测试，覆盖正数、负数和零值浮点数的往返转换，以及不完整浮点数据的处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct floating-point value decoding and encoding to preserve packet alignment and support sensor data reliably.

Bug Fixes:
- Decode protocol type 0x05 as an IEEE 754 64-bit floating-point value, preventing stream misalignment when parsing sensor data.

Enhancements:
- Add float serialization support for protocol values.

Tests:
- Extend protocol tests with positive, negative, and zero float round trips and incomplete float-data handling.

</details>