### PR TITLE
Fix HA startup timeout by using async_create_background_task

### DIFF
--- a/custom_components/lifesmart/core/protocol.py
+++ b/custom_components/lifesmart/core/protocol.py
@@ -139,6 +139,9 @@ class LifeSmartProtocol:
         if isinstance(value, bool):  # 处理布尔值
             return b"\x02" if value else b"\x03"
 
+        if isinstance(value, float):  # 处理浮点数 (64位 IEEE 754 Double)
+            return b"\x05" + struct.pack(">d", value)
+
         if isinstance(value, int):  # 处理整数
             if not -0x80000000 <= value <= 0x7FFFFFFF:
                 raise ValueError(f"int 超出 32-bit 有符号范围: {value}")
@@ -230,17 +233,11 @@ class LifeSmartProtocol:
                 zz = self._decode_varint(stream)
                 return (zz >> 1) ^ -(zz & 1)  # 反 ZigZag
 
-            if data_type == 0x05:  # HEX类型处理
-                index = stream.read(1)[0]
-                hex_data = stream.read(8)
-                if len(hex_data) < 8:
-                    raise EOFError("HEX 数据不完整")
-                return {
-                    "type": "HEX",
-                    "index": index,
-                    "value": hex_data.hex(),
-                    "raw": hex_data,
-                }
+            elif data_type == 0x05:  # 64位浮点数 (Double IEEE 754)
+                raw_bytes = stream.read(8)
+                if len(raw_bytes) < 8:
+                    raise EOFError("Float 数据不完整")
+                return struct.unpack(">d", raw_bytes)[0]
 
             elif data_type == 0x06:  # 时间戳类型处理
                 index = stream.read(1)[0]

--- a/custom_components/lifesmart/hub.py
+++ b/custom_components/lifesmart/hub.py
@@ -235,8 +235,8 @@ class LifeSmartHub:
             )
 
             # 创建连接任务
-            self._local_task = self.hass.async_create_task(
-                self.client.async_connect(self._local_update_callback)
+            self._local_task = self.hass.async_create_background_task(
+                self.client.async_connect(self._local_update_callback), "lifesmart_local_tcp"
             )
 
             # 获取设备列表

--- a/custom_components/lifesmart/hub.py
+++ b/custom_components/lifesmart/hub.py
@@ -236,7 +236,8 @@ class LifeSmartHub:
 
             # 创建连接任务
             self._local_task = self.hass.async_create_background_task(
-                self.client.async_connect(self._local_update_callback), "lifesmart_local_tcp"
+                self.client.async_connect(self._local_update_callback),
+                "lifesmart_local_tcp",
             )
 
             # 获取设备列表

--- a/custom_components/lifesmart/tests/test_hub.py
+++ b/custom_components/lifesmart/tests/test_hub.py
@@ -431,7 +431,9 @@ class TestLifeSmartHub:
                 await asyncio.sleep(100)  # 永不结束的任务
 
             real_task = asyncio.create_task(dummy_task())
-            with patch.object(hass, "async_create_task", return_value=real_task):
+            with patch.object(
+                hass, "async_create_background_task", return_value=real_task
+            ):
                 result = await hub.async_setup()
 
                 assert result is True, "本地模式设置应该成功"

--- a/custom_components/lifesmart/tests/test_protocol.py
+++ b/custom_components/lifesmart/tests/test_protocol.py
@@ -90,6 +90,9 @@ class TestProtocolDataTypeEncoding:
             ("ListMixed", [1, True, "test", None]),
             ("DictEmpty", {}),
             ("DictSimple", {"key": "value", "number": 42}),
+            ("FloatPositive", 71.8),
+            ("FloatNegative", -2.5),
+            ("FloatZero", 0.0),
             ("SpecialNull", "::NULL::"),
         ],
     )
@@ -467,13 +470,13 @@ class TestProtocolErrorHandling:
         with pytest.raises(EOFError, match="字符串数据不足"):
             protocol._parse_value(BytesIO(incomplete_string_data), 0x11)  # 字符串类型码
 
-    def test_incomplete_hex_data(self, protocol: LifeSmartProtocol):
-        """测试十六进制数据不完整的情况。"""
-        # 模拟HEX数据不完整（需要8字节但只有4字节）
-        incomplete_hex_data = b"\x01\x11\x22\x33"
+    def test_incomplete_float_data(self, protocol: LifeSmartProtocol):
+        """测试浮点数数据不完整的情况。"""
+        # 模拟Float数据不完整（需要8字节但只有4字节）
+        incomplete_float_data = b"\x01\x11\x22\x33"
 
-        with pytest.raises(EOFError, match="HEX 数据不完整"):
-            protocol._parse_value(BytesIO(incomplete_hex_data), 0x05)  # HEX类型码
+        with pytest.raises(EOFError, match="Float 数据不完整"):
+            protocol._parse_value(BytesIO(incomplete_float_data), 0x05)  # 浮点数类型码
 
     def test_incomplete_timestamp_data(self, protocol: LifeSmartProtocol):
         """测试时间戳数据不完整的情况。"""


### PR DESCRIPTION
When `lifesmart` connects to local hubs, it blocks the Home Assistant startup because the background TCP listening task was spawned using `self.hass.async_create_task`. HA tracks these tasks during bootstrap, and waits up to 60 seconds for them to finish, causing the `Setup timed out for bootstrap` warning and delaying system readiness. This changes it to `async_create_background_task` to fix the timeout.

## Sourcery 摘要

防止本地 hub 连接阻塞 Home Assistant 启动，并支持浮点协议值。

新功能：
- 添加对 64 位浮点协议值的编码和解码支持。

错误修复：
- 通过将 TCP 监听器作为后台任务运行，防止本地 hub 连接延迟 Home Assistant 的启动就绪状态。

测试：
- 增加对正值、负值和零浮点值以及不完整浮点负载的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

防止本地集线器连接阻塞 Home Assistant 启动，并支持浮点协议值。

新功能：
- 增加对 64 位浮点协议值编码和解码的支持。

错误修复：
- 将本地集线器 TCP 连接作为后台任务运行，使其不会延迟 Home Assistant 的启动就绪。

测试：
- 覆盖正数、负数和零浮点值，以及不完整的浮点负载。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent local hub connections from blocking Home Assistant startup and support floating-point protocol values.

New Features:
- Add support for encoding and decoding 64-bit floating-point protocol values.

Bug Fixes:
- Run the local hub TCP connection as a background task so it does not delay Home Assistant startup readiness.

Tests:
- Cover positive, negative, and zero floating-point values and incomplete floating-point payloads.

</details>

</details>